### PR TITLE
feat(M018/S04): Worktree correctness — error chains, orphan detection, cleanup_all MCP tool

### DIFF
--- a/crates/assay-cli/src/commands/worktree.rs
+++ b/crates/assay-cli/src/commands/worktree.rs
@@ -237,8 +237,9 @@ fn handle_worktree_list(json: bool) -> anyhow::Result<i32> {
         // ANSI overhead for colored spec column
         let extra = if color { super::ANSI_COLOR_OVERHEAD } else { 0 };
 
+        let orphan_marker = if entry.is_orphan { " [orphan]" } else { "" };
         println!(
-            "  {:<sw$}  {:<bw$}  {}",
+            "  {:<sw$}  {:<bw$}  {}{orphan_marker}",
             spec_display,
             entry.branch,
             entry.path.display(),

--- a/crates/assay-cli/src/commands/worktree.rs
+++ b/crates/assay-cli/src/commands/worktree.rs
@@ -130,7 +130,7 @@ fn resolve_dirs(
     if !ad.is_dir() {
         bail!("No Assay project found. Run `assay init` first.");
     }
-    let config = assay_core::config::load(&root).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let config = assay_core::config::load(&root)?;
     let worktree_dir =
         assay_core::worktree::resolve_worktree_dir(worktree_dir_override, &config, &root);
     let specs_dir = root.join(".assay").join(&config.specs_dir);
@@ -145,8 +145,7 @@ fn handle_worktree_create(
 ) -> anyhow::Result<i32> {
     let (root, worktree_dir, specs_dir) = resolve_dirs(worktree_dir_override)?;
 
-    let info = assay_core::worktree::create(&root, name, base, &worktree_dir, &specs_dir, None)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let info = assay_core::worktree::create(&root, name, base, &worktree_dir, &specs_dir, None)?;
 
     if json {
         let output = serde_json::to_string_pretty(&info)?;
@@ -170,7 +169,7 @@ fn handle_worktree_create(
 fn handle_worktree_list(json: bool) -> anyhow::Result<i32> {
     let (root, _worktree_dir, _specs_dir) = resolve_dirs(None)?;
 
-    let result = assay_core::worktree::list(&root).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let result = assay_core::worktree::list(&root)?;
     for warning in &result.warnings {
         tracing::warn!("{warning}");
     }
@@ -259,8 +258,7 @@ fn handle_worktree_status(
     let (_root, worktree_dir, _specs_dir) = resolve_dirs(worktree_dir_override)?;
     let worktree_path = worktree_dir.join(name);
 
-    let st =
-        assay_core::worktree::status(&worktree_path, name).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let st = assay_core::worktree::status(&worktree_path, name)?;
 
     if json {
         let output = serde_json::to_string_pretty(&st)?;
@@ -324,7 +322,7 @@ fn handle_worktree_cleanup(
         let is_dirty = match assay_core::worktree::status(&worktree_path, spec_slug) {
             Ok(s) => s.dirty,
             Err(assay_core::error::AssayError::WorktreeNotFound { .. }) => false,
-            Err(e) => return Err(anyhow::anyhow!("{e}")),
+            Err(e) => return Err(e.into()),
         };
 
         if is_dirty {
@@ -349,8 +347,7 @@ fn handle_worktree_cleanup(
         true
     };
 
-    assay_core::worktree::cleanup(&root, &worktree_path, spec_slug, effective_force)
-        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    assay_core::worktree::cleanup(&root, &worktree_path, spec_slug, effective_force)?;
 
     if json {
         let output = serde_json::json!({"removed": spec_slug});
@@ -367,7 +364,7 @@ fn handle_worktree_cleanup_all(
     force: bool,
     json: bool,
 ) -> anyhow::Result<i32> {
-    let result = assay_core::worktree::list(root).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let result = assay_core::worktree::list(root)?;
     for warning in &result.warnings {
         tracing::warn!("{warning}");
     }

--- a/crates/assay-core/src/worktree.rs
+++ b/crates/assay-core/src/worktree.rs
@@ -360,6 +360,7 @@ pub fn create(
         path: worktree_path,
         branch: branch_name,
         base_branch: Some(base),
+        is_orphan: false,
     })
 }
 
@@ -388,11 +389,27 @@ pub fn list(project_root: &Path) -> Result<WorktreeListResult> {
                 path: wt.path,
                 branch: branch.to_string(),
                 base_branch,
+                is_orphan: false,
             })
         })
         .collect();
 
     entries.sort_by(|a, b| a.spec_slug.cmp(&b.spec_slug));
+
+    // Cross-reference with sessions to populate is_orphan.
+    // Reuses the same logic as detect_orphans() but inline to avoid recursion.
+    let assay_dir = project_root.join(".assay");
+    for entry in &mut entries {
+        let metadata = read_metadata(&entry.path);
+        entry.is_orphan = match metadata.and_then(|m| m.session_id) {
+            None => true, // No session_id — orphaned
+            Some(sid) => match crate::work_session::load_session(&assay_dir, &sid) {
+                Err(_) => true, // Session doesn't exist on disk — orphaned
+                Ok(session) => session.phase.is_terminal(), // Terminal phase — orphaned
+            },
+        };
+    }
+
     Ok(WorktreeListResult { entries, warnings })
 }
 

--- a/crates/assay-core/src/worktree.rs
+++ b/crates/assay-core/src/worktree.rs
@@ -404,8 +404,17 @@ pub fn list(project_root: &Path) -> Result<WorktreeListResult> {
         entry.is_orphan = match metadata.and_then(|m| m.session_id) {
             None => true, // No session_id — orphaned
             Some(sid) => match crate::work_session::load_session(&assay_dir, &sid) {
-                Err(_) => true, // Session doesn't exist on disk — orphaned
                 Ok(session) => session.phase.is_terminal(), // Terminal phase — orphaned
+                Err(AssayError::WorkSessionNotFound { .. }) => true, // Session file missing — orphaned
+                Err(e) => {
+                    // I/O or parse error — conservatively not orphaned; warn so operator can investigate
+                    tracing::warn!(
+                        spec_slug = %entry.spec_slug,
+                        error = %e,
+                        "worktree list: could not load session to determine orphan status, assuming active"
+                    );
+                    false
+                }
             },
         };
     }
@@ -555,26 +564,14 @@ pub fn cleanup(
 /// - Its `session_id` points to a session in a terminal phase (Completed or Abandoned)
 ///
 /// Worktrees with an active (non-terminal) session are NOT orphaned.
-pub fn detect_orphans(project_root: &Path, assay_dir: &Path) -> Result<Vec<WorktreeInfo>> {
+pub fn detect_orphans(project_root: &Path, _assay_dir: &Path) -> Result<Vec<WorktreeInfo>> {
     let list_result = list(project_root)?;
-    let mut orphans = Vec::new();
-
-    for entry in list_result.entries {
-        let metadata = read_metadata(&entry.path);
-        let is_orphan = match metadata.and_then(|m| m.session_id) {
-            None => true, // No session_id — orphaned
-            Some(sid) => match crate::work_session::load_session(assay_dir, &sid) {
-                Err(_) => true, // Session doesn't exist on disk — orphaned
-                Ok(session) => session.phase.is_terminal(), // Terminal phase — orphaned
-            },
-        };
-
-        if is_orphan {
-            orphans.push(entry);
-        }
-    }
-
-    Ok(orphans)
+    // list() already populates is_orphan on every entry via session cross-reference.
+    Ok(list_result
+        .entries
+        .into_iter()
+        .filter(|e| e.is_orphan)
+        .collect())
 }
 
 /// Detect if the current working directory is inside a linked worktree.
@@ -1626,6 +1623,52 @@ cmd = "echo ok"
         assert!(
             !result.entries[0].is_orphan,
             "worktree with active session should NOT be marked as orphan"
+        );
+    }
+
+    #[test]
+    fn test_list_marks_terminal_session_as_orphan() {
+        let (_tmp, _wt_tmp, root, specs_dir) = setup_repo();
+        let worktree_base = _wt_tmp.path().join("worktrees");
+        let assay_dir = root.join(".assay");
+
+        // Create a session and complete it (terminal phase).
+        // complete_session requires prior record_gate_result to advance state.
+        let session = crate::work_session::start_session(
+            &assay_dir,
+            "auth-flow",
+            worktree_base.join("auth-flow"),
+            "claude",
+            None,
+        )
+        .expect("start_session failed");
+        crate::work_session::record_gate_result(
+            &assay_dir,
+            &session.id,
+            "run-001",
+            "gate_eval",
+            None,
+        )
+        .expect("record_gate_result failed");
+        crate::work_session::complete_session(&assay_dir, &session.id, None)
+            .expect("complete_session failed");
+
+        // Create worktree linked to the completed (terminal) session
+        create(
+            &root,
+            "auth-flow",
+            Some("main"),
+            &worktree_base,
+            &specs_dir,
+            Some(&session.id),
+        )
+        .expect("create failed");
+
+        let result = list(&root).expect("list failed");
+        assert_eq!(result.entries.len(), 1);
+        assert!(
+            result.entries[0].is_orphan,
+            "worktree linked to a terminal session should be marked as orphan"
         );
     }
 }

--- a/crates/assay-core/src/worktree.rs
+++ b/crates/assay-core/src/worktree.rs
@@ -1569,4 +1569,63 @@ cmd = "echo ok"
         result_mut.warnings.push("test warning".to_string());
         assert_eq!(result_mut.warnings.len(), 1);
     }
+
+    #[test]
+    fn test_list_marks_orphan_entries() {
+        let (_tmp, _wt_tmp, root, specs_dir) = setup_repo();
+        let worktree_base = _wt_tmp.path().join("worktrees");
+
+        // Create worktree with no session_id — should be orphaned
+        create(
+            &root,
+            "auth-flow",
+            Some("main"),
+            &worktree_base,
+            &specs_dir,
+            None,
+        )
+        .expect("create failed");
+
+        let result = list(&root).expect("list failed");
+        assert_eq!(result.entries.len(), 1);
+        assert!(
+            result.entries[0].is_orphan,
+            "worktree with no session_id should be marked as orphan"
+        );
+    }
+
+    #[test]
+    fn test_list_marks_non_orphan_entries() {
+        let (_tmp, _wt_tmp, root, specs_dir) = setup_repo();
+        let worktree_base = _wt_tmp.path().join("worktrees");
+        let assay_dir = root.join(".assay");
+
+        // Create an active session
+        let session = crate::work_session::start_session(
+            &assay_dir,
+            "auth-flow",
+            worktree_base.join("auth-flow"),
+            "claude",
+            None,
+        )
+        .expect("start_session failed");
+
+        // Create worktree linked to the active session
+        create(
+            &root,
+            "auth-flow",
+            Some("main"),
+            &worktree_base,
+            &specs_dir,
+            Some(&session.id),
+        )
+        .expect("create failed");
+
+        let result = list(&root).expect("list failed");
+        assert_eq!(result.entries.len(), 1);
+        assert!(
+            !result.entries[0].is_orphan,
+            "worktree with active session should NOT be marked as orphan"
+        );
+    }
 }

--- a/crates/assay-mcp/src/server.rs
+++ b/crates/assay-mcp/src/server.rs
@@ -289,6 +289,24 @@ pub struct WorktreeCleanupParams {
     pub worktree_dir: Option<String>,
 }
 
+/// Parameters for the `worktree_cleanup_all` tool.
+#[derive(Deserialize, JsonSchema)]
+pub struct WorktreeCleanupAllParams {
+    /// Only remove orphaned worktrees (no linked active WorkSession). Defaults to true.
+    #[schemars(
+        description = "Only remove orphaned worktrees (default: true). Set false to remove all."
+    )]
+    #[serde(default)]
+    pub orphans_only: Option<bool>,
+
+    /// Force cleanup of dirty worktrees. Defaults to true for MCP (non-interactive).
+    #[schemars(
+        description = "Force cleanup even if worktree has uncommitted changes (default: true)"
+    )]
+    #[serde(default)]
+    pub force: Option<bool>,
+}
+
 /// Parameters for the `merge_check` tool.
 #[derive(Deserialize, JsonSchema)]
 pub struct MergeCheckParams {
@@ -2768,7 +2786,61 @@ impl AssayServer {
         Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 
-    // TODO(M002): worktree_cleanup_all tool — deferred per D005 (MCP additive-only)
+    /// Remove all worktrees (or only orphaned ones).
+    #[tool(
+        description = "Remove all worktrees (or only orphaned ones). Defaults to orphans_only=true and force=true. Returns the count of removed worktrees."
+    )]
+    pub async fn worktree_cleanup_all(
+        &self,
+        params: Parameters<WorktreeCleanupAllParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let cwd = resolve_cwd()?;
+        let config = match load_config(&cwd) {
+            Ok(c) => c,
+            Err(err_result) => return Ok(err_result),
+        };
+
+        let orphans_only = params.0.orphans_only.unwrap_or(true);
+        let force = params.0.force.unwrap_or(true);
+
+        let result = match assay_core::worktree::list(&cwd) {
+            Ok(r) => r,
+            Err(e) => return Ok(domain_error(&e)),
+        };
+
+        let entries: Vec<_> = if orphans_only {
+            result.entries.into_iter().filter(|e| e.is_orphan).collect()
+        } else {
+            result.entries
+        };
+
+        let mut removed = 0u32;
+        let worktree_dir = assay_core::worktree::resolve_worktree_dir(None, &config, &cwd);
+        for entry in &entries {
+            let worktree_path = if entry.path.is_absolute() {
+                entry.path.clone()
+            } else {
+                worktree_dir.join(&entry.spec_slug)
+            };
+            match assay_core::worktree::cleanup(&cwd, &worktree_path, &entry.spec_slug, force) {
+                Ok(()) => removed += 1,
+                Err(e) => {
+                    tracing::warn!(
+                        spec_slug = %entry.spec_slug,
+                        error = %e,
+                        "worktree_cleanup_all: failed to remove worktree"
+                    );
+                }
+            }
+        }
+
+        tracing::info!(removed, orphans_only, "worktree_cleanup_all completed");
+
+        let response = serde_json::json!({ "removed": removed, "orphans_only": orphans_only });
+        let json = serde_json::to_string(&response)
+            .map_err(|e| McpError::internal_error(format!("serialization failed: {e}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(json)]))
+    }
 
     /// Remove a worktree and its associated branch.
     #[tool(
@@ -9839,5 +9911,75 @@ depends_on = ["chunk-a"]
             result.is_error.unwrap_or(false),
             "should fail when slug is missing for milestone source"
         );
+    }
+
+    // ── worktree_cleanup_all tests ──────────────────────────────────
+
+    #[tokio::test]
+    #[serial]
+    async fn test_worktree_cleanup_all_appears_in_tools() {
+        let server = AssayServer::new();
+        let tools = server.tool_router.list_all();
+        let tool_names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            tool_names.contains(&"worktree_cleanup_all"),
+            "worktree_cleanup_all should be in tool list, got: {tool_names:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_worktree_cleanup_all_empty_list() {
+        let dir = create_project(r#"project_name = "cleanup-test""#);
+        // git init so worktree::list() can run
+        std::process::Command::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git init failed");
+        std::process::Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git config failed");
+        std::process::Command::new("git")
+            .args(["config", "user.name", "Test"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git config failed");
+        std::process::Command::new("git")
+            .args(["add", "."])
+            .current_dir(dir.path())
+            .output()
+            .expect("git add failed");
+        std::process::Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(dir.path())
+            .output()
+            .expect("git commit failed");
+
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let server = AssayServer::new();
+        let result = server
+            .worktree_cleanup_all(Parameters(WorktreeCleanupAllParams {
+                orphans_only: Some(true),
+                force: Some(true),
+            }))
+            .await
+            .unwrap();
+
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "should succeed with no worktrees"
+        );
+        let text = result.content.first().and_then(|c| match &c.raw {
+            RawContent::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        });
+        assert!(text.is_some(), "result should have text content");
+        let parsed: serde_json::Value = serde_json::from_str(text.unwrap()).unwrap();
+        assert_eq!(parsed["removed"], 0, "no worktrees to remove");
+        assert_eq!(parsed["orphans_only"], true);
     }
 }

--- a/crates/assay-types/src/worktree.rs
+++ b/crates/assay-types/src/worktree.rs
@@ -71,6 +71,10 @@ pub struct WorktreeInfo {
     /// Populated on create and list (from metadata), `None` when metadata is missing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub base_branch: Option<String>,
+    /// Whether this worktree is orphaned (no linked active WorkSession).
+    /// Populated by `worktree::list()` when cross-referencing sessions.
+    #[serde(default)]
+    pub is_orphan: bool,
 }
 
 inventory::submit! {

--- a/crates/assay-types/tests/schema_roundtrip.rs
+++ b/crates/assay-types/tests/schema_roundtrip.rs
@@ -546,6 +546,7 @@ fn worktree_info_validates() {
         path: std::path::PathBuf::from("/tmp/worktrees/auth-flow"),
         branch: "assay/auth-flow".to_string(),
         base_branch: Some("main".to_string()),
+        is_orphan: false,
     });
 }
 
@@ -556,6 +557,7 @@ fn worktree_info_without_base_branch_validates() {
         path: std::path::PathBuf::from("/tmp/worktrees/auth-flow"),
         branch: "assay/auth-flow".to_string(),
         base_branch: None,
+        is_orphan: false,
     });
 }
 

--- a/crates/assay-types/tests/snapshots/schema_snapshots__worktree-info-schema.snap
+++ b/crates/assay-types/tests/snapshots/schema_snapshots__worktree-info-schema.snap
@@ -18,6 +18,11 @@ expression: schema.to_value()
       "description": "The git branch checked out in this worktree (e.g., `assay/auth-flow`).",
       "type": "string"
     },
+    "is_orphan": {
+      "default": false,
+      "description": "Whether this worktree is orphaned (no linked active WorkSession).\nPopulated by `worktree::list()` when cross-referencing sessions.",
+      "type": "boolean"
+    },
     "path": {
       "description": "Absolute path to the worktree directory.",
       "type": "string"


### PR DESCRIPTION
## S04: Worktree correctness

Closes M018/S04. Fixes four worktree pain points for parallel runs.

### What's in this PR

**T01 — CLI error chain preservation (R104)**
- Replaced 7 `.map_err(|e| anyhow::anyhow!("{e}"))` with `?`/`.into()` in `assay-cli/src/commands/worktree.rs`
- Full `AssayError` source chain now surfaces in CLI error output

**T01 — WorktreeInfo.is_orphan field (R105)**
- Added `#[serde(default)] pub is_orphan: bool` to `WorktreeInfo`
- `worktree::list()` cross-references metadata session_id against `work_session::load_session()` inline to populate orphan status
- Inline implementation avoids recursion with `detect_orphans()` (which calls `list()`)
- Schema snapshot updated

**T02 — CLI orphan display + unit tests (R105)**
- `[orphan]` marker shown in non-JSON `worktree list` output
- 2 new integration tests: `test_list_marks_orphan_entries`, `test_list_marks_non_orphan_entries`

**R106 — Collision prevention (pre-existing, verified)**
- 3 pre-existing collision tests pass; no new code needed

**T03 — worktree_cleanup_all MCP tool (R107)**
- New `worktree_cleanup_all` tool: `orphans_only: bool` (default true), `force: bool` (default true)
- Returns `{ "removed": N, "orphans_only": bool }`
- Individual failures warned, not fatal
- Removes the `TODO(M002)` placeholder
- 2 handler tests added

### Verification

```
just ready  # all pass
```

All 4 requirements validated: R104, R105, R106, R107.